### PR TITLE
Added the ability to use blocking Write implementation.

### DIFF
--- a/example-std/Cargo.lock
+++ b/example-std/Cargo.lock
@@ -3,26 +3,10 @@
 version = 3
 
 [[package]]
-name = "bare-metal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "critical-section"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1706d332edc22aef4d9f23a6bb1c92360a403013c291af51247a737472dcae6"
-dependencies = [
- "bare-metal",
- "critical-section 1.1.1",
-]
 
 [[package]]
 name = "critical-section"
@@ -66,7 +50,7 @@ dependencies = [
 name = "defmt-serial"
 version = "0.6.0"
 dependencies = [
- "critical-section 0.2.8",
+ "critical-section",
  "defmt",
  "embedded-hal",
  "nb 1.1.0",
@@ -86,7 +70,7 @@ dependencies = [
 name = "example-std"
 version = "0.1.0"
 dependencies = [
- "critical-section 1.1.1",
+ "critical-section",
  "defmt",
  "defmt-serial",
  "embedded-hal",

--- a/example-std/src/main.rs
+++ b/example-std/src/main.rs
@@ -1,5 +1,5 @@
 #![feature(never_type)]
-use embedded_hal::serial::Write;
+use embedded_hal::blocking::serial::Write;
 use std::io::{self, Write as _};
 
 struct StdoutSerial;
@@ -7,12 +7,12 @@ struct StdoutSerial;
 impl Write<u8> for StdoutSerial {
     type Error = !;
 
-    fn write(&mut self, word: u8) -> nb::Result<(), !> {
-        io::stdout().write(&[word]).unwrap();
+    fn bwrite_all(&mut self, word: &[u8]) -> Result<(), !> {
+        io::stdout().write(word).unwrap();
         Ok(())
     }
 
-    fn flush(&mut self) -> nb::Result<(), !> {
+    fn bflush(&mut self) -> Result<(), !> {
         io::stdout().flush().unwrap();
         Ok(())
     }


### PR DESCRIPTION
It is useful to also be able to use the `blocking::Write` trait implementation. Some libraries like `embassy-rs` only implement the blocking version of the Write trait but not the non blocking one.