### PR TITLE
Add support for more targets via `portable-atomic` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/gauteh/defmt-serial"
 critical-section = "1.1"
 defmt = "0.3"
 embedded-io = "0.7"
+portable-atomic = {version = "1.13", default-features = false}
 
 [dev-dependencies]
 cortex-m-rt = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,8 @@
 //! ```
 
 use core::ptr::addr_of_mut;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::Ordering;
+use portable_atomic::AtomicBool;
 use defmt::global_logger;
 use embedded_io::Write;
 


### PR DESCRIPTION
Hi,

Some target architectures (like the MSP430 and AVR devices) don't have atomic types in the Rust standard library, so to enable support for these targets I've added a feature that uses [`portable-atomic`](https://docs.rs/portable-atomic/latest/portable_atomic/) to provide implementations for these.

As far as I know it would be fine to unconditionally replace the `core::sync::atomic` import with the equivalent `portable-atomic` one, as `portable-atomic` simply wraps the standard library types on architectures that already have atomics in the standard library. I don't have the ability to test all the existing architectures though, so out of an abundance of caution (and the opportunity to avoid a new dependency in the typical configuration) I only include it behind a feature gate.

Any comments or edits are welcome.