### PR TITLE
Bugfixes and espflash compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ static_cell = "2"
 version = "0.3"
 features = [ "ambiq-sdk", "sparkfun-redboard-nano", "rt"]
 git = "https://github.com/gauteh/ambiq-rs"
+
+[features]
+# Include magic bytes to mix regular output with defmt when using espflash
+espflash = []

--- a/example-std/.cargo/config.toml
+++ b/example-std/.cargo/config.toml
@@ -11,3 +11,6 @@ rustflags = [
 
 [build]
 target = "x86_64-unknown-linux-musl"
+
+[env]
+DEFMT_LOG="trace"

--- a/example-std/Cargo.lock
+++ b/example-std/Cargo.lock
@@ -48,11 +48,12 @@ dependencies = [
 
 [[package]]
 name = "defmt-serial"
-version = "0.10.0"
+version = "0.12.0"
 dependencies = [
  "critical-section",
  "defmt",
  "embedded-io",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -81,9 +82,9 @@ checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "portable-atomic"
-version = "1.6.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro-error"

--- a/example-std/Cargo.toml
+++ b/example-std/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 embedded-io = "0.7"
 defmt = "0.3.2"
-defmt-serial = { version = "*", path = "../" }
+defmt-serial = { path = "../" }
 nb = "1.0.0"
 critical-section = { version = "1.1", features = ["std"]}
 static_cell = "2.0.0"

--- a/example-std/src/main.rs
+++ b/example-std/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(never_type)]
 use core::convert::Infallible;
 use embedded_io::{Write, ErrorType};
 use static_cell::StaticCell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn defmt_serial<T: EraseWrite>(serial: &'static mut T) {
     unsafe {
         critical_section::with(|_| {
             assert!(
-                (&raw mut ERASEDWRITE).as_ref().is_none(),
+                (&raw mut ERASEDWRITE).as_ref().unwrap().is_none(),
                 "Tried to assign serial port when one was already assigned."
             );
             ERASEDWRITE = Some(serial);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,9 @@ unsafe impl defmt::Logger for GlobalSerialLogger {
             CS_RESTORE = restore;
         }
 
+        #[cfg(feature = "espflash")]
+        write_serial(&[0xFF, 0x00]);
+        
         unsafe { (&raw mut ENCODER).as_mut().unwrap().start_frame(write_serial) }
     }
 


### PR DESCRIPTION
Espflash has an option to show both the regular output and defmt encoded logs simultaneously. This would be important in order to see crash logs that don't propagate to the rust panic handler.

And some other improvements